### PR TITLE
fix: Keep smooth lerp animation for teleport while maintaining drag (…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "toddler-toy-pwa",
-  "version": "1.0.42",
+  "version": "1.0.43",
   "description": "Montessori-aligned interactive toddler toy PWA",
   "main": "index.html",
   "scripts": {

--- a/src/game.js
+++ b/src/game.js
@@ -27,7 +27,7 @@ class GameScene extends Phaser.Scene {
 
     create() {
         // Version logging for troubleshooting
-        console.log('🎯 TODDLER TOY v1.0.42 - Modern Drag & Touch Polish - Build:', new Date().toISOString());
+        console.log('🎯 TODDLER TOY v1.0.43 - Smooth Teleport + Draggable Fix - Build:', new Date().toISOString());
         
         // Initialize configuration manager if not already provided
         if (!this.configManager) {
@@ -492,14 +492,14 @@ class GameScene extends Phaser.Scene {
             // Re-voice the object being dragged
             this.speechManager.speakText(hitObject, 'both');
         } else if (this.speechManager.getIsSpeaking() && this.speechManager.getCurrentSpeakingObject()) {
-            // Jump speaking object to tap location AND start dragging immediately
+            // Teleport speaking object to tap location with smooth lerp AND make it draggable
             // FIX: This fixes the "teleport then drag is wonky" issue
             const speakingObj = this.speechManager.getCurrentSpeakingObject();
-            this.moveObjectTo(speakingObj, x, y, false); // false = immediate positioning, no lerp
+            this.moveObjectTo(speakingObj, x, y, true); // true = smooth lerp animation
             this.audioManager.updateTonePosition(x, y, speakingObj.id);
             this.particleManager.createSpawnBurst(x, y);
             this.autoCleanupManager.updateObjectTouchTime(speakingObj);
-            // Start dragging immediately so finger movement works
+            // Start dragging immediately so finger movement works during/after lerp
             this.startDragging(speakingObj, x, y);
         } else if (!this.speechManager.getIsSpeaking()) {
             // Spawn new object
@@ -540,10 +540,8 @@ class GameScene extends Phaser.Scene {
     startDragging(obj, x, y) {
         if (!obj || !obj.active) return;
 
-        // Stop any smooth movement animations for this object
-        if (this.movementManager.hasMovingObject(obj.id)) {
-            this.movementManager.clearMovement(obj.id);
-        }
+        // Don't cancel smooth movements - let finger movement naturally take over
+        // This allows smooth lerp animations to complete if user doesn't move finger
 
         // Set drag state
         this.isDragging = true;


### PR DESCRIPTION
…v1.0.43)

**What Changed:**
- Restored smooth lerp animation when teleporting object to tap location
- Object still becomes immediately draggable (previous fix preserved)
- Best of both worlds: smooth animation + instant draggability

**Behavior:**
1. User taps empty space while object is speaking
2. Object smoothly lerps toward tap location (nice animation preserved)
3. Object is immediately marked as draggable (scale up visual feedback)
4. If user moves finger: Drag takes over with instant positioning
5. If user holds still: Lerp completes smoothly to target

**Technical Fix:**
- Changed teleport back to `moveObjectTo(obj, x, y, true)` (smooth lerp)
- Removed `clearMovement()` call from `startDragging()`
- Finger movement in `onInputPointerMove` naturally overrides lerp
- Allows smooth animations to complete if user doesn't drag immediately

This gives the polished feel requested - smooth teleport animation with immediate draggability if the user wants it!